### PR TITLE
Slac epics build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,11 @@ RUN yum -y install git gcc make gcc-c++
 
 RUN mkdir $HOME/EPICS \
 && cd $HOME/EPICS \
-&& git clone https://github.com/epics-base/epics-base.git \
+&& git clone https://github.com/epics-base/epics-base.git \ 
 && cd epics-base \
-&& make
+&& make # TODO: change this to the slac-epics base: https://github.com/slac-epics/epics-base which is currently not building
 
 # configuring environment for epics ##TODO: there's probably a cleaner way...
 RUN echo "export EPICS_BASE=${HOME}/EPICS/epics-base" >> $HOME/.bashrc && source $HOME/.bashrc \
 && echo "export EPICS_HOST_ARCH=$(${EPICS_BASE}/startup/EpicsHostArch)" >> $HOME/.bashrc && source $HOME/.bashrc\
 && echo "export PATH=${EPICS_BASE}/bin/${EPICS_HOST_ARCH}:${PATH}" >> $HOME/.bashrc && source $HOME/.bashrc 
-
-RUN bash
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,14 @@
 FROM registry.access.redhat.com/ubi7/ubi
 
 # needed to build epics-base
-RUN yum -y install git gcc make gcc-c++
+RUN yum -y install git gcc make gcc-c++ ncurses-devel wget
 
-RUN mkdir $HOME/EPICS \
-&& cd $HOME/EPICS \
-&& git clone https://github.com/epics-base/epics-base.git \ 
-&& cd epics-base \
-&& make # TODO: change this to the slac-epics base: https://github.com/slac-epics/epics-base which is currently not building
+RUN wget http://mirror.centos.org/centos/7/os/x86_64/Packages/readline-devel-6.2-11.el7.x86_64.rpm && rpm -i readline-devel-6.2-11.el7.x86_64.rpm
+
+RUN mkdir $HOME/EPICS && cd $HOME/EPICS && git clone https://github.com/slac-epics/epics-base
+RUN cd $HOME/EPICS/epics-base && EPICS_BASE=${HOME}/EPICS/epics-base EPICS_HOST_ARCH=$(${EPICS_BASE}/startup/EpicsHostArch) make
 
 # configuring environment for epics ##TODO: there's probably a cleaner way...
-RUN echo "export EPICS_BASE=${HOME}/EPICS/epics-base" >> $HOME/.bashrc && source $HOME/.bashrc \
-&& echo "export EPICS_HOST_ARCH=$(${EPICS_BASE}/startup/EpicsHostArch)" >> $HOME/.bashrc && source $HOME/.bashrc\
-&& echo "export PATH=${EPICS_BASE}/bin/${EPICS_HOST_ARCH}:${PATH}" >> $HOME/.bashrc && source $HOME/.bashrc 
+RUN echo "export EPICS_BASE=${HOME}/EPICS/epics-base" >> $HOME/.bashrc 
+RUN source $HOME/.bashrc && echo "export EPICS_HOST_ARCH=$(${EPICS_BASE}/startup/EpicsHostArch)" >> $HOME/.bashrc
+RUN source $HOME/.bashrc && echo "export PATH=${EPICS_BASE}/bin/${EPICS_HOST_ARCH}:${PATH}" >> $HOME/.bashrc

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,4 @@ build:
 
 .PHONY: run
 run:
-	@docker run -it --rm epics_rhel_hello_world || true
+	@docker run -it --rm epics_rhel_hello_world bash || true


### PR DESCRIPTION
PR addresses two breaking errors when switching this container to build the: https://github.com/slac-epics/epics-base instead of the conventional epics-base:

1. Our makefile requires `EPICS_HOST_ARCH` is defined prior to invoking make
2. At least on the redhat base image, yum could not find readline-devel and didn't come with needed ncurses-devel installed