### PR TITLE
feat(initIOC.hutch): add necessary files for it to return success

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ ENV T_A=rhel7-x86_64
 ENV PYPS_SITE_TOP=/reg/g/pcds/pyps
 ENV IOC_DATA=/reg/d/iocData
 ENV HUTCH=wtf
+ENV HUTCH_HOSTNAME=ctl-$HUTCH-cam-03
 ENV PSPKG_ROOT=/reg/g/pcds/pkg_mgr
-
 
 #ioc.sh
 RUN mkdir -p /usr/lib/systemd/scripts
@@ -59,10 +59,14 @@ COPY fs/etc /reg/g/pcds/pkg_mgr/etc
 #somewhat silly symlink mechanism to control prod iocmanager releases per hutch. Here we point to latest, could be a "version" to
 RUN mkdir -p $PYPS_SITE_TOP/config/$HUTCH/ && cd $PYPS_SITE_TOP/config/$HUTCH/ && ln -s $PYPS_SITE_TOP/apps/iocmanager/latest iocmanager
 
-# this sucks hard but we're trying to reach parity with this existing system, in the future use any other pkg_mgr than one rolled from scratch plzx
+# this sucks hard but we're trying to reach parity with this existing system, in the future use any other pkg_mgr than one rolled from scratch plz!
 RUN mkdir -p $PSPKG_ROOT/release/controls-basic-0.0.1/x86_64-rhel7-gcc48-opt
 COPY fs/pkg_mgr $PSPKG_ROOT/release/controls-basic-0.0.1/x86_64-rhel7-gcc48-opt
 
+# tragic mechanism for globally tracking 'os' per machine hostname, this is messy and problematicl initIOC.hutch:14 needs this file to exist
+RUN mkdir -p /reg/g/pcds/pyps/config/.host/ && cd /reg/g/pcds/pyps/config/.host/ && touch $HUTCH_HOSTNAME 
 
-
-###############################################################################################
+# another tough relic: this one sets up "environment" for soft IOCs to run. kill this with fire as well.
+RUN mkdir -p /reg/d/iocCommon/All
+COPY fs/hutch_env_scripts/ /reg/d/iocCommon/All   
+##############################################################################################

--- a/fs/hutch_env_scripts/common_env.sh
+++ b/fs/hutch_env_scripts/common_env.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Setup the environment needed for consistent launching of soft IOC's
+
+# Set the common directory env variables
+if   [ -f  /usr/local/lcls/epics/config/common_dirs.sh ]; then
+    source /usr/local/lcls/epics/config/common_dirs.sh 
+elif [ -f  /reg/g/pcds/pyps/config/common_dirs.sh ]; then
+    source /reg/g/pcds/pyps/config/common_dirs.sh
+elif [ -f  /afs/slac/g/lcls/epics/config/common_dirs.sh ]; then
+    source /afs/slac/g/lcls/epics/config/common_dirs.sh
+fi
+
+# Setup EPICS env
+if [ `uname -m` = "armv7l" ]; then
+    source $SETUP_SITE_TOP/epicsenv-3.15.5-apalis-2.0.sh
+elif uname -r | fgrep -w -s el5 > /dev/null; then
+	source $SETUP_SITE_TOP/epicsenv-7.0.2-2.0.sh
+else
+    source $SETUP_SITE_TOP/epicsenv-cur.sh
+fi
+
+PROCSERV_VERSION=${PROCSERV_VERSION=2.8.0-1.3.0}
+if [ "$EPICS_HOST_ARCH" == "linux-x86" ]; then
+    PROCSERV_VERSION=2.8.0-1.0.0
+fi
+if [ "$EPICS_HOST_ARCH" == "linux-x86_64" ]; then
+    PROCSERV_VERSION=2.8.0-1.0.0
+fi
+if [ "$EPICS_HOST_ARCH" == "linux-arm-apalis" ]; then
+    PROCSERV_VERSION=2.8.0-1.3.0
+    CROSS_ARCH=arm-cortexa9_neon-linux-gnueabihf
+    pathmunge $PACKAGE_SITE_TOP/procServ/procServ-$PROCSERV_VERSION/install/$CROSS_ARCH/bin
+    PYTHON_VERSION=${PYTHON_VERSION=2.7.13}
+    pathmunge       $PACKAGE_SITE_TOP/python/python$PYTHON_VERSION/install/$CROSS_ARCH/bin
+    ldpathmunge     $PACKAGE_SITE_TOP/python/python$PYTHON_VERSION/install/$CROSS_ARCH/lib
+    pythonpathmunge $PACKAGE_SITE_TOP/python/python$PYTHON_VERSION/install/$CROSS_ARCH/lib/python2.7/site-packages
+elif [ -e $PSPKG_ROOT/release/procServ/$PROCSERV_VERSION/$EPICS_HOST_ARCH/bin/procServ ]; then
+    pathmunge $PSPKG_ROOT/release/procServ/$PROCSERV_VERSION/$EPICS_HOST_ARCH/bin
+fi
+export PROCSERV_EXE=`which procServ`
+if [ -n "$PROCSERV_EXE" ]; then
+    export PROCSERV="$PROCSERV_EXE --allow --ignore ^D^C --logstamp"
+else
+    echo "Warning: procServ path not found!"
+fi
+export IOC_HOST=`hostname -s`
+
+# Get the creation time
+export CREATE_TIME=`date '+%m%d%Y_%H%M%S'`
+
+if [ "$IOC_USER" == "" ]; then
+    echo Warning: Set IOC_USER env variable in your startup.cmd file before running common_env.sh
+else
+    # Run processes as the correct IOC userid
+    if [ "$IOC_USER" == "$USER" ]; then
+        export RUNUSER="/bin/bash -c"
+    elif [ -f /sbin/runuser ]; then
+        export RUNUSER="/sbin/runuser $IOC_USER -s /bin/bash --preserve-environment -c"
+    else
+        export RUNUSER="su $IOC_USER -c"
+    fi
+
+    # Make sure the host iocData directory exists for the caRepeater log
+    if [ ! -d $IOC_DATA/$IOC_HOST ]; then
+        $RUNUSER "mkdir -p $IOC_DATA/$IOC_HOST"
+        if [ -n "$(which setfacl)" ]; then
+            $RUNUSER "setfacl -d -m group:ps-ioc:rwx $IOC_DATA/$IOC_HOST"
+            $RUNUSER "setfacl    -m group:ps-ioc:rwx $IOC_DATA/$IOC_HOST"
+        fi
+    fi
+    $RUNUSER "mkdir -p $IOC_DATA/$IOC_HOST/archive"
+    $RUNUSER "mkdir -p $IOC_DATA/$IOC_HOST/autosave"
+    $RUNUSER "mkdir -p $IOC_DATA/$IOC_HOST/iocInfo"
+    $RUNUSER "mkdir -p $IOC_DATA/$IOC_HOST/logs"
+
+    # Make sure the soft ioc iocData directories exist and have the right permissions
+    if [ "$IOC" == "" ]; then
+        echo Warning: Set IOC env variable in your startup.cmd file before running common_env.sh
+    else
+        didmake=0
+        if [ ! -d $IOC_DATA/$IOC ]; then
+            $RUNUSER "mkdir -p $IOC_DATA/$IOC"
+            if [ -n "$(which setfacl)" ]; then
+                $RUNUSER "setfacl -d -m group:ps-ioc:rwx $IOC_DATA/$IOC"
+                $RUNUSER "setfacl    -m group:ps-ioc:rwx $IOC_DATA/$IOC"
+            fi
+            didmake=1
+        fi
+        if [ ! -d $IOC_DATA/$IOC/autosave ]; then
+            $RUNUSER "mkdir -p $IOC_DATA/$IOC/autosave"
+            didmake=1
+        fi
+        if [ ! -d $IOC_DATA/$IOC/archive ]; then
+            $RUNUSER "mkdir -p $IOC_DATA/$IOC/archive"
+            didmake=1
+        fi
+        if [ ! -d $IOC_DATA/$IOC/iocInfo ]; then
+            $RUNUSER "mkdir -p $IOC_DATA/$IOC/iocInfo"
+            didmake=1
+        fi
+        if [ ! -d $IOC_DATA/$IOC/logs ]; then
+            $RUNUSER "mkdir -p $IOC_DATA/$IOC/logs"
+            didmake=1
+        fi
+        if [ $didmake == 1 ]; then
+            $RUNUSER "chgrp ps-ioc -R $IOC_DATA/$IOC"
+            if [ `uname -m` = "armv7l" ]; then
+                $RUNUSER "chmod 0775 -R $IOC_DATA/$IOC"
+            else
+                $RUNUSER "chmod ug+rws $IOC_DATA/$IOC $IOC_DATA/$IOC/*"
+            fi
+        fi
+    fi
+fi

--- a/fs/hutch_env_scripts/wtf_env.sh
+++ b/fs/hutch_env_scripts/wtf_env.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# First set your IOC user
+export IOC_USER=lfeioc
+
+# Setup the environment needed for consistent launching of soft IOC's
+source /reg/d/iocCommon/All/common_env.sh
+


### PR DESCRIPTION
Adding "configuration" file paths needed for initIOC.hutch to return correctly. 

Future work will include making sure the "hutch environment scripts" included in this PR themselves return correctly. 

This is a quagmire but we have to remember once ironed out we are putting ourselves in a position to succeed and make iterative progress.